### PR TITLE
Remove margin from popup container

### DIFF
--- a/style.css
+++ b/style.css
@@ -751,7 +751,6 @@ footer .btn:active {
 }
 
 .pop-section .pop-container {
-  margin: 2% 5% 2% 4%;
   background: #fff;
   border-radius: 20px;
   position: relative;
@@ -1127,12 +1126,10 @@ footer .btn:active {
   }
 
   .pop-section .pop-container {
-    margin: 10% 15% 10% 15%;
     background: #fff;
     border-radius: 20px;
     position: relative;
     display: none;
-    max-height: 720px;
   }
 
   .pop-section .pop-container.active {


### PR DESCRIPTION
The issue was created by my Morning session team. In Peer to Peer code review, they suggested I remove the unwanted huge margins I had given to my pop-up window container. So I removed the margins and the pop-up container is looking more professional now. Thanks to my Morning sessions team ❤🤗.